### PR TITLE
Ignore errors if `ps cax | grep` fails

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,16 +103,20 @@ const webpackConfig = {
     hot: true,
     on: {
       listening: () => {
-        execSync('ps cax | grep "Google Chrome"')
-        execSync(
-          `osascript chrome.applescript "${encodeURI(
-            `http://localhost:${process.env.PORT}`
-          )}"`,
-          {
-            cwd: __dirname,
-            stdio: 'ignore',
-          }
-        )
+        try {
+          execSync('ps cax | grep "Google Chrome"')
+          execSync(
+            `osascript chrome.applescript "${encodeURI(
+              `http://localhost:${process.env.PORT}`
+            )}"`,
+            {
+              cwd: __dirname,
+              stdio: 'ignore',
+            }
+          )
+        } catch(err) {
+          // …
+        }
       },
     },
   },


### PR DESCRIPTION
on `listen` event of _webpack-serve_